### PR TITLE
Fix incorrect repository URLs in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jeremy/node-red-contrib-mealie"
+    "url": "https://github.com/democratize-technology/node-red-contrib-mealie"
   },
   "bugs": {
-    "url": "https://github.com/jeremy/node-red-contrib-mealie/issues"
+    "url": "https://github.com/democratize-technology/node-red-contrib-mealie/issues"
   },
-  "homepage": "https://github.com/jeremy/node-red-contrib-mealie#readme",
+  "homepage": "https://github.com/democratize-technology/node-red-contrib-mealie#readme",
   "engines": {
     "node": ">=20.0.0"
   }


### PR DESCRIPTION
## Summary
- Updates repository URLs in package.json to point to the correct democratize-technology organization
- Fixes npm registry metadata and improves package discoverability

## Changes
- Updated repository.url from jeremy/node-red-contrib-mealie to democratize-technology/node-red-contrib-mealie
- Updated bugs.url to point to correct issues page
- Updated homepage to point to correct repository

Fixes #2

🤖 Generated with [Claude Code](https://claude.ai/code)