### PR TITLE
Fix version inconsistency between package.json and README (Issue #1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-mealie",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-mealie",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "node-mealie": "^0.1.1"
@@ -4843,7 +4843,7 @@
       }
     },
     "node_modules/node-mealie": {
-      "version": "0.1.1",
+      "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/node-mealie/-/node-mealie-0.1.1.tgz",
       "integrity": "sha512-11JEngiTcne6eGRJztoynA9dKZo+jiiwo2J5F3BrYPadvfl2C1i6+eV4P4Edzk0/ihJI31h7eyOjqmFz0hcZSA==",
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4843,7 +4843,7 @@
       }
     },
     "node_modules/node-mealie": {
-      "version": "0.2.0",
+      "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/node-mealie/-/node-mealie-0.1.1.tgz",
       "integrity": "sha512-11JEngiTcne6eGRJztoynA9dKZo+jiiwo2J5F3BrYPadvfl2C1i6+eV4P4Edzk0/ihJI31h7eyOjqmFz0hcZSA==",
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-mealie",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Node-RED nodes for Mealie recipe management system",
   "keywords": [
     "node-red",


### PR DESCRIPTION
## Summary
- Bumps package version from 0.1.1 to 0.2.0 to match README feature references
- Resolves version inconsistency where README mentioned "Domain Nodes (v0.2.0+)" but package.json showed 0.1.1
- All development phases including Domain-Operation Architecture (Phase 7) are marked as complete

## Test plan
- [x] Run existing test suite to ensure no regressions
- [x] Verify version numbers are consistent across package.json and package-lock.json
- [x] Confirm README version references now align with package version

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)