### PR TITLE
Extract duplicated error transformation logic

### DIFF
--- a/docs/architecture/error-handling.md
+++ b/docs/architecture/error-handling.md
@@ -115,7 +115,7 @@ Starting from version 0.2.1, the package includes intelligent retry logic for tr
 
 ### 3. Error Transformation
 
-API errors and other exceptions are transformed into the appropriate MealieError subtype:
+API errors and other exceptions are transformed into the appropriate MealieError subtype using the `transformError` utility function:
 
 - HTTP 401/403 errors → AuthenticationError
 - HTTP 400 errors → ValidationError
@@ -123,6 +123,8 @@ API errors and other exceptions are transformed into the appropriate MealieError
 - HTTP 5xx errors → MealieError (with statusCode preserved for retry logic)
 - Network exceptions → NetworkError
 - Other exceptions → MealieError
+
+The `transformError` function provides a single source of truth for error transformation logic, ensuring consistent behavior across all code paths (retry-enabled and retry-disabled).
 
 ### 4. Error Handling in Nodes
 
@@ -203,6 +205,14 @@ const result = await withErrorHandling(
   async () => await client.recipes.getRecipe(slug),
   'Failed to retrieve recipe'
 );
+```
+
+### transformError
+
+Transforms various error types into appropriate MealieError subclasses:
+
+```javascript
+const transformedError = transformError(originalError);
 ```
 
 ### handleError

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -117,6 +117,46 @@ const retryPolicy = retry(
 );
 
 /**
+ * Transform various error types into appropriate MealieError subclasses
+ * @param {Error} error - The error to transform
+ * @returns {MealieError} - The transformed error
+ */
+function transformError(error) {
+    // Network errors
+    if (error.name === 'FetchError' || error.code === 'ECONNREFUSED' || error.code === 'ETIMEDOUT') {
+        return new NetworkError(`Connection failed: ${error.message}`, error);
+    }
+    
+    // Rate limiting
+    if (error.statusCode === 429) {
+        return new RateLimitError('Rate limit exceeded', error);
+    }
+    
+    // Authentication errors
+    if (error.statusCode === 401 || error.statusCode === 403) {
+        return new AuthenticationError('Authentication failed', error);
+    }
+    
+    // Validation errors
+    if (error.statusCode === 400) {
+        return new ValidationError('Invalid request data', error);
+    }
+    
+    // Already a MealieError - return as-is
+    if (error instanceof MealieError) {
+        return error;
+    }
+    
+    // Generic error transformation
+    const mealieError = new MealieError(error.message, 'UNKNOWN_ERROR', error);
+    // Preserve statusCode for retry policy
+    if (error.statusCode) {
+        mealieError.statusCode = error.statusCode;
+    }
+    return mealieError;
+}
+
+/**
  * Wrap async Mealie operations with error handling and retry logic
  * @param {Function} operation - The async operation to execute
  * @param {object} node - The Node-RED node instance
@@ -127,34 +167,7 @@ async function withErrorHandling(operation, node) {
         try {
             return await operation();
         } catch (error) {
-            // Transform error but don't retry
-            if (error.name === 'FetchError' || error.code === 'ECONNREFUSED' || error.code === 'ETIMEDOUT') {
-                throw new NetworkError(`Connection failed: ${error.message}`, error);
-            }
-            
-            if (error.statusCode === 429) {
-                throw new RateLimitError('Rate limit exceeded', error);
-            }
-            
-            if (error.statusCode === 401 || error.statusCode === 403) {
-                throw new AuthenticationError('Authentication failed', error);
-            }
-            
-            if (error.statusCode === 400) {
-                throw new ValidationError('Invalid request data', error);
-            }
-            
-            // Re-throw as generic MealieError if unknown
-            if (!(error instanceof MealieError)) {
-                const mealieError = new MealieError(error.message, 'UNKNOWN_ERROR', error);
-                // Preserve statusCode for retry policy
-                if (error.statusCode) {
-                    mealieError.statusCode = error.statusCode;
-                }
-                throw mealieError;
-            }
-            
-            throw error;
+            throw transformError(error);
         }
     }
 
@@ -165,37 +178,9 @@ async function withErrorHandling(operation, node) {
         }
         
         try {
-            const result = await operation();
-            return result;
+            return await operation();
         } catch (error) {
-            // Transform known error types and decide if we should retry
-            if (error.name === 'FetchError' || error.code === 'ECONNREFUSED' || error.code === 'ETIMEDOUT') {
-                throw new NetworkError(`Connection failed: ${error.message}`, error);
-            }
-            
-            if (error.statusCode === 429) {
-                throw new RateLimitError('Rate limit exceeded', error);
-            }
-            
-            if (error.statusCode === 401 || error.statusCode === 403) {
-                throw new AuthenticationError('Authentication failed', error);
-            }
-            
-            if (error.statusCode === 400) {
-                throw new ValidationError('Invalid request data', error);
-            }
-            
-            // Re-throw as generic MealieError if unknown
-            if (!(error instanceof MealieError)) {
-                const mealieError = new MealieError(error.message, 'UNKNOWN_ERROR', error);
-                // Preserve statusCode for retry policy
-                if (error.statusCode) {
-                    mealieError.statusCode = error.statusCode;
-                }
-                throw mealieError;
-            }
-            
-            throw error;
+            throw transformError(error);
         }
     });
 }
@@ -207,6 +192,7 @@ module.exports = {
     ValidationError,
     ConfigurationError,
     RateLimitError,
+    transformError,
     withErrorHandling,
     handleError
 };

--- a/tests/lib/errors_spec.js
+++ b/tests/lib/errors_spec.js
@@ -66,6 +66,96 @@ describe('Error Utilities', function() {
         });
     });
     
+    describe('transformError', function() {
+        it('should transform FetchError to NetworkError', function() {
+            const fetchError = new Error('Connection failed');
+            fetchError.name = 'FetchError';
+            
+            const transformed = errors.transformError(fetchError);
+            transformed.should.be.instanceof(errors.NetworkError);
+            transformed.message.should.equal('Connection failed: Connection failed');
+        });
+        
+        it('should transform ECONNREFUSED to NetworkError', function() {
+            const connError = new Error('Connection refused');
+            connError.code = 'ECONNREFUSED';
+            
+            const transformed = errors.transformError(connError);
+            transformed.should.be.instanceof(errors.NetworkError);
+            transformed.message.should.equal('Connection failed: Connection refused');
+        });
+        
+        it('should transform ETIMEDOUT to NetworkError', function() {
+            const timeoutError = new Error('Connection timeout');
+            timeoutError.code = 'ETIMEDOUT';
+            
+            const transformed = errors.transformError(timeoutError);
+            transformed.should.be.instanceof(errors.NetworkError);
+            transformed.message.should.equal('Connection failed: Connection timeout');
+        });
+        
+        it('should transform 429 status to RateLimitError', function() {
+            const rateLimitError = new Error('Too Many Requests');
+            rateLimitError.statusCode = 429;
+            
+            const transformed = errors.transformError(rateLimitError);
+            transformed.should.be.instanceof(errors.RateLimitError);
+            transformed.message.should.equal('Rate limit exceeded');
+        });
+        
+        it('should transform 401 status to AuthenticationError', function() {
+            const authError = new Error('Unauthorized');
+            authError.statusCode = 401;
+            
+            const transformed = errors.transformError(authError);
+            transformed.should.be.instanceof(errors.AuthenticationError);
+            transformed.message.should.equal('Authentication failed');
+        });
+        
+        it('should transform 403 status to AuthenticationError', function() {
+            const authError = new Error('Forbidden');
+            authError.statusCode = 403;
+            
+            const transformed = errors.transformError(authError);
+            transformed.should.be.instanceof(errors.AuthenticationError);
+            transformed.message.should.equal('Authentication failed');
+        });
+        
+        it('should transform 400 status to ValidationError', function() {
+            const validationError = new Error('Bad Request');
+            validationError.statusCode = 400;
+            
+            const transformed = errors.transformError(validationError);
+            transformed.should.be.instanceof(errors.ValidationError);
+            transformed.message.should.equal('Invalid request data');
+        });
+        
+        it('should return MealieError instances unchanged', function() {
+            const mealieError = new errors.MealieError('Test', 'SPECIFIC_CODE');
+            
+            const transformed = errors.transformError(mealieError);
+            transformed.should.equal(mealieError);
+        });
+        
+        it('should wrap unknown errors as MealieError', function() {
+            const unknownError = new Error('Unknown error');
+            
+            const transformed = errors.transformError(unknownError);
+            transformed.should.be.instanceof(errors.MealieError);
+            transformed.should.have.property('code', 'UNKNOWN_ERROR');
+            transformed.message.should.equal('Unknown error');
+        });
+        
+        it('should preserve statusCode for unknown errors', function() {
+            const unknownError = new Error('Server error');
+            unknownError.statusCode = 500;
+            
+            const transformed = errors.transformError(unknownError);
+            transformed.should.be.instanceof(errors.MealieError);
+            transformed.should.have.property('statusCode', 500);
+        });
+    });
+    
     describe('handleError', function() {
         let mockNode;
         let msg;


### PR DESCRIPTION
## Summary

• Extract error transformation logic into a dedicated `transformError()` helper function
• Eliminate DRY violation in `withErrorHandling()` where the same transformation logic was duplicated
• Export `transformError` function for better testability and potential reuse

## Problem Addressed

Resolves #17 - The error transformation logic was duplicated between retry-enabled and retry-disabled code paths in `lib/errors.js`. This violation of DRY principle made maintenance harder and created risk of inconsistencies.

## Solution

- Created `transformError()` helper function that centralizes all error transformation logic
- Replaced duplicated error transformation blocks in both code paths with calls to the new function
- Added comprehensive unit tests specifically for the `transformError` function
- Updated error handling documentation to mention the new utility
- Exported the function to enable unit testing and potential future reuse

## Test Plan

✅ All existing tests pass (340 tests)
✅ Added 10 new unit tests specifically for `transformError` function
✅ Verified error transformation behavior is identical in both retry paths
✅ No breaking changes - all existing functionality preserved

## Benefits

- **Single Source of Truth**: Error transformation logic now exists in one place
- **Easier Maintenance**: Adding new error types only requires changes in one location
- **Consistency**: Guaranteed identical behavior between retry-enabled and retry-disabled paths
- **Testability**: Can unit test transformation logic separately from retry logic
- **Readability**: Cleaner, more focused functions with clear responsibilities

🤖 Generated with [Claude Code](https://claude.ai/code)